### PR TITLE
add ErrTokenIsProcessed's logic in List (keys.go)

### DIFF
--- a/lokalise/keys.go
+++ b/lokalise/keys.go
@@ -69,6 +69,10 @@ func (c *KeysService) List(ctx context.Context, projectID string, options ListKe
 		return model.KeysResponse{}, err
 	}
 	applyPaged(resp, &res.Paged)
+
+	if getErrorStatusCode(resp) == int(423) {
+		return res, ErrTokenIsProcessed
+	}
 	return res, apiError(resp)
 }
 


### PR DESCRIPTION
we need `ErrTokenIsProcessed` in `List` to do corresponding logic in `goapi` repo